### PR TITLE
Replace unused shortcodes with currently used shortcodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# PHPStorm Files #
+##################
+.idea/

--- a/_pages/development-and-workflow.md
+++ b/_pages/development-and-workflow.md
@@ -49,6 +49,10 @@ The way to deal with this is to have as much consistency as is reasonable. Tools
 *   **Local Development:** while the quality of virtualization tools is progressing, they are still complex and require their own upkeep; losing a day of productivity due to local dev problems is always a pain. In addition, it’s very difficult to represent a scalable multi-server environment on a developer’s laptop, so some compromises here are inevitable.
 *   **Setup Cost:** for many teams without an existing platform or scripts, setting up a best practice workflow is a costly investment of time, which may or may not be supported by the project budget. Unfortunately many projects suffer because the proper tooling isn’t put into place, resulting in stressful deployment windows.
 
-[do_widget_area]
+<!---
+Do not edit below this line. Automatically pulls in resources.
+-->
+
+[social_links]
 
 [link-library settings="1" categorylistoverride="13"]

--- a/_pages/elastic-architecture.md
+++ b/_pages/elastic-architecture.md
@@ -35,6 +35,10 @@ The common challenges running an elastic, horizontally scalable, and highly avai
 * **Shared Media:** One of WordPress’s most important functions is managing media — images, documents, etc — that go along with posts. These are placed in the `uploads` area of `wp-content`, but in order to make WordPress horizontally scalable, you must find a way for uploads to be available to all PHP App servers. Open-source tools like GlusterFS, NFS, and Ceph are common answers, and Amazon’s EFS is an option in that cloud ecosystem.
 * **Consistency:** A classic downfall for clusters is a lack of consistency. If not all the environments at each layer have the same characteristics and configuration, that will compromise elasticity and create maddeningly illusive bugs. Likewise, changes to the application itself — e.g. a WordPress core update — must be deployed consistently, which requires some kind of orchestration and workflow. These are challenges solved by systems administrators and DevOps practitioners, using tools such as Chef, Puppet, Ansible, and Capistrano. There are also cloud tools, such as AWS’s CloudFormation, or OpenStack’s HEAT that can help.
 
-[do_widget_area]
+<!---
+Do not edit below this line. Automatically pulls in resources.
+-->
+
+[social_links]
 
 [link-library categorylistoverride="5"]

--- a/_pages/object-caching.md
+++ b/_pages/object-caching.md
@@ -34,6 +34,10 @@ WordPress stores its object cache in as simple named key=&gt;value pairs, so the
 *   **Eviction:** Most popular cache backends have storage limits, and use a LRU (last resource used) strategy for “evicting” items from the cache when more room is needed. This can create unexpected expirations and can sometimes confuse developers.
 *   **Optimization:** Using a persistent storage backend to cache objects for a highly dynamic application isn’t as simple as implementing a full page cache. You’ll need to smartly cache data based on an equation of how expensive it is to generate, how frequently it’s requested (aka likelihood of actually being served), and how much capacity you have in your persistent storage backend.
 
-[do_widget_area]
+<!---
+Do not edit below this line. Automatically pulls in resources.
+-->
+
+[social_links]
 
 [link-library settings="1" categorylistoverride="8"]

--- a/_pages/page-caching.md
+++ b/_pages/page-caching.md
@@ -39,6 +39,10 @@ The most popular open source reverse proxy is Varnish, but Nginx also has revers
 *   **Cookies:** most Proxies rely heavily on browser-side characteristics — e.g. cookies — to decide whether a request can be given a cached response, or if it must be passed back to WordPress. If the reverse proxy, or WordPress, are improperly configured, then too many requests can be sent back to WordPress, which can drastically decrease the effectiveness of the proxy cache. This can present some challenges in a world where there are many different systems using Cookies differently.
 *   **Complexity:** for many developers, the conceptual complexity of introducing a new system, and not having the web-browser talk “directly” to WordPress, can create confusion around how to debug problems. Taking the time to insure everyone on the team is comfortable with the implementation is important. 
 
-[do_widget_area]
+<!---
+Do not edit below this line. Automatically pulls in resources.
+-->
+
+[social_links]
 
 [link-library settings="1" categorylistoverride="10"]

--- a/_pages/query-performance.md
+++ b/_pages/query-performance.md
@@ -34,6 +34,10 @@ Even with best-practice architecture, an important part of scalability hygiene i
 *   **Debuggability:** when dealing with troublesome queries, you not only need access to the slow query log, but also to safely and reliably replicate the situation order to conclusively resolve the issue. That means having an environment to debug in with all the data needed to trigger the slow query. It also means taking the time to isolate where in the site code the query is being generated, so that an alternative can be implemented.
 *   **Regressions:** as noted above, the impacts from a query of death can be swift. For sites with large datasets, it is important to consider the implications of new queries, as well as to test them before they are released into production. 
 
-[do_widget_area]
+<!---
+Do not edit below this line. Automatically pulls in resources.
+-->
+
+[social_links]
 
 [link-library settings="1" categorylistoverride="11"]

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -27,3 +27,9 @@ published: true
 
 ### Development and Workflow
 [link-library settings="1" categorylistoverride="13"]  
+
+<!---
+Do not edit below this line. Automatically pulls in resources.
+-->
+
+[social_links]

--- a/_pages/scale.md
+++ b/_pages/scale.md
@@ -5,7 +5,6 @@ layout: page
 published: true
 ---
 <div id="wpas"></div>
-
 ## Can WordPress Scale?
 
 ### Yes. But there are requirements:
@@ -21,17 +20,20 @@ WordPress can push hundreds of millions, even billions of pageviews a month; it 
 
 This site is intended to communicate hard-won best practices from teams that have deep real-world experience in running WordPress at scale. They provide a useful starting place for scalable implementations, for both development teams as well as site owners.
 
-<div class="bulletbox bb-left">
-<h2>Developers</h2>
-We all stand on the shoulders of giants. Learn trusted architectural patterns for scalable website infrastructure, as well as the optimizations that nearly all big sites leverage. 
-</div>
-<div class="bulletbox bb-right">
-<h2>Site Owners</h2>
+[bullet_box align="left" title="Developers"]
+We all stand on the shoulders of giants. Learn trusted architectural patterns for scalable website infrastructure, as well as the optimizations that nearly all big sites leverage.
+[/bullet_box]
+[bullet_box align="right" title="Site Owners"]
 When and how you invest in scalability is one of the most important business decisions you'll make. Use this site to have productive discussions with your developers and vendors.
-</div>
-
+[/bullet_box]
 Confident your WordPress implementation has everything it needs? Congrats! Want to learn more about these techniques? Read on.
 
-[do_widget_area]
+<!---
+Do not edit below this line. Automatically pulls in resources.
+-->
+
+[article_links]
+
+[social_links]
 
 [link-library settings="1" categorylistoverride="9"]

--- a/_pages/searching-for-scale.md
+++ b/_pages/searching-for-scale.md
@@ -33,6 +33,6 @@ Most large-scale sites want a better answer for core content search, and the abi
 Do not edit below this line. Automatically pulls in resources.
 -->
 
-[do_widget_area]
+[social_links]
 
 [link-library settings="1" categorylistoverride="12"]


### PR DESCRIPTION
During the theme rebuild we removed multiple plugins and added custom shortcodes for the functionality needed to replace them.
