### PR TITLE
CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+This repo is linked to the [scalewp.io](https://scalewp.io) website. The core website content is managed here to facilitate contributions from the community. 
+
+While we do some amount of discussion in issues, the best contributions start with a concrete suggestion in the form of a pull request.
+
+Pull requests merged to master go directly to the site.
+
+### Editing existing pages
+
+Pull requests can be made on any files within this repository. Please fork the repository and name your branch based on the change you are making.
+
+The WordPress site to which this repository connects uses the [GitHub Flavored Markdown for WordPress](https://github.com/makotokw/wp-gfm) plugin to render text. So the markdown formatting used in this repository by GitHub should match that seen on the WordPress site.
+
+#### Shortcodes
+
+Many of the files within this repository use WordPress shortcodes for related links and share widgets. Leave those sections as-is when making Pull Requests.
+
+#### Images
+
+Images are added within the git repository within the top-level `diagrams` folder rather than from the WordPress user interface. Images can be linked using GitHub's 'raw' submain using urls like https://raw.githubusercontent.com/pantheon-systems/wordpress-at-scale/master/diagrams/simple_cluster.png. For an example, see [the Elastic Architecture page](https://github.com/pantheon-systems/wordpress-at-scale/blob/master/_pages/elastic-architecture.md). 
+
+### Adding pages
+
+Here is an example of text that would go in `/_pages/new-file.md`.
+
+```
+---
+post_title: New File
+layout: page
+published: true
+---
+
+New Text goes here
+
+## You can use headings.
+
+```
+
+The new page will be picked up by the WordPress site once the new file is merged to master. This sync happens through the [WordPress GitHub Sync plugin](https://wordpress.org/plugins/wp-github-sync/). The page will have a numeric ID once WordPress saves it in the database. Following this save, the WordPress GitHub Sync plugin will write back to this repository on GitHub to include the numeric ID and permalink as part of the YAML Frontmatter at the top of the .md file.
+
+#### Properties to include
+
+When adding a new file include the following properties in the YAML Frontmatter at the top of the .md file.
+
+* `post_title` - The name of the post needs to correspond to the name of the .md file (See the next section on "Naming the file")
+* `layout` - This value should simply be `page`.
+* `published` - This value should simply be `true`. The [WordPress GitHub Sync plugin](https://wordpress.org/plugins/wp-github-sync/) does allow for the syncing of unpublished content but our configuration does not include such pages.
+
+#### Naming the file
+
+The new file on GitHub must have a name that matches the title within the post. WordPress GitHub Sync names files based on title and will delete mismatched files which makes git history harder to track. [The enforcement of this matching is currently manual step in the PR process](https://github.com/pantheon-systems/wordpress-at-scale/issues/2). The name of the file should be the same as the title with all special characters removed and spaces converted to hyphens.
+
+### Resource links
+
+Currently we are tracking the resource links only in the WordPress database. You'll notice the code for the resources page is just a [collection of shortcodes](https://github.com/pantheon-systems/wordpress-at-scale/blob/master/_pages/resources.md). However, we are very open to including more resources of value. Please [file an issue](https://github.com/pantheon-systems/wordpress-at-scale/issues/new?labels=resource) if you have a resource suggestion.

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -4,17 +4,17 @@ post_title: About
 layout: page
 published: true
 ---
-##About WordPress at Scale
+## About WordPress at Scale
 
 WordPress now powers about [1 in every 4 websites](https://ma.tt/2015/11/seventy-five-to-go/) and continues to grow. Many of these sites have massive audiences and traffic and that [trend is accelerating](https://pantheon.io/blog/wordpress-moves-upmarket). In order to serve this growing market, we need more of our developers to understand how to build WordPress sites that scale. 
 
-###Enter the Community
+### Enter the Community
 This site is the product of lots of real world experience, many discussions and collaboration from our community. This site couldn’t have happened without [our contributors](/contributors/) coming together to share these best practices. 
 
-###It’s Not Done Yet!
+### It’s Not Done Yet!
 This is a living repository of knowledge. Help us improve this site and [contribute your insights](/contribute). All of our content is stored in GitHub and editable via Pull Requests.
 
-###About the Site
+### About the Site
 This site is made with [WordPress](https://wordpress.org/), was designed and built by a team at [Pantheon](https://pantheon.io/) and is a living example of all of these best practices in use. 
 
 Our theme is built with the [Underscores starter theme](http://underscores.me/). Notable plugins include [WordPress GitHub Sync](https://github.com/mAAdhaTTah/wordpress-github-sync) and [GitHub Flavored Markdown for WordPress](https://github.com/makotokw/wp-gfm) to sync content from Github, [Google (XML) Sitemaps Generator for WordPress](http://www.arnebrachhold.de/projects/wordpress-plugins/google-xml-sitemaps-generator) to help our search engine friends and [WP Redis](https://wordpress.org/plugins/wp-redis/) to make use of Redis for [persistent object caching](./object-caching)

--- a/_pages/contribute.md
+++ b/_pages/contribute.md
@@ -5,55 +5,20 @@ layout: page
 published: true
 ---
 
-## Contributing to this website.
+## Contributing to this website
 
 [Contribute to WordPress at Scale on GitHub](https://github.com/pantheon-systems/wordpress-at-scale). We use a version control repository to collaboratively maintain these pages. They have [many authors who have contributed over time](/contributors), and your additional input and insight is welcome!
 
-### Editing existing pages
+For more information on how to get started, see the [CONTRIBUTING.md](https://github.com/pantheon-systems/wordpress-at-scale/blob/master/CONTRIBUTING.md) file in the GitHub repository. 
 
-Pull requests can be made on any files within this repository. Please fork the repository and name your branch based on the change you are making.
+## Other ways to help
 
-The WordPress site to which this repository connects uses the [GitHub Flavored Markdown for WordPress](https://github.com/makotokw/wp-gfm) plugin to render text. So the markdown formatting used in this repository by GitHub should match that seen on the WordPress site.
+The value of this initiative is as a "center of gravity" for information about WordPress at Scale. If you are supportive of this effort, but don't have specific content contributions, we can still use your help.
 
-#### Shortcodes
+### Building the resource library
 
-Many of the files within this repository use WordPress shortcodes for related links and share widgets. Leave those sections as-is when making Pull Requests.
+One site will never have all the answers, and so we need help collecting links to valued resources. Do you have a go-to guide you use for solving specific problems at scale? [Let us know](https://github.com/pantheon-systems/wordpress-at-scale/issues/new?labels=resource) and we can add it to our resources page. 
 
-#### Images
+### Spreading the word
 
-Images are added within the git repository within the top-level `diagrams` folder rather than from the WordPress user interface. Images can be linked using GitHub's 'raw' submain using urls like https://raw.githubusercontent.com/pantheon-systems/wordpress-at-scale/master/diagrams/simple_cluster.png. For an example, see [the Elastic Architecture page](https://github.com/pantheon-systems/wordpress-at-scale/blob/master/_pages/elastic-architecture.md). 
-
-### Adding pages
-
-Here is an example of text that would go in `/_pages/new-file.md`.
-
-```
----
-post_title: New File
-layout: page
-published: true
----
-
-New Text goes here
-
-## You can use headings.
-
-```
-
-The new page will be picked up by the WordPress site once the new file is merged to master. This sync happens through the [WordPress GitHub Sync plugin](https://wordpress.org/plugins/wp-github-sync/). The page will have a numeric ID once WordPress saves it in the database. Following this save, the WordPress GitHub Sync plugin will write back to this repository on GitHub to include the numeric ID and permalink as part of the YAML Frontmatter at the top of the .md file.
-
-#### Properties to include
-
-When adding a new file include the following properties in the YAML Frontmatter at the top of the .md file.
-
-* `post_title` - The name of the post needs to correspond to the name of the .md file (See the next section on "Naming the file")
-* `layout` - This value should simply be `page`.
-* `published` - This value should simply be `true`. The [WordPress GitHub Sync plugin](https://wordpress.org/plugins/wp-github-sync/) does allow for the syncing of unpublished content but our configuration does not include such pages.
-
-#### Naming the file
-
-The new file on GitHub must have a name that matches the title within the post. WordPress GitHub Sync names files based on title and will delete mismatched files which makes git history harder to track. [The enforcement of this matching is currently manual step in the PR process](https://github.com/pantheon-systems/wordpress-at-scale/issues/2). The name of the file should be the same as the title with all special characters removed and spaces converted to hyphens.
-
-### Resoource links
-
-Currently we are tracking the resource links only in the WordPress database. You'll notice the code for the resources page is just a [collection of shortcodes](https://github.com/pantheon-systems/wordpress-at-scale/blob/master/_pages/resources.md). However, we are very open to including more resources of value. Please [file an issue](https://github.com/pantheon-systems/wordpress-at-scale/issues) if you have a resource suggestion.
+Making the most out of this effort means having this content be widely viewed. Help us make others aware of this site: you can tweet it out of course, but more importantly you can reference it in your own work or on other issue threads. Let's put an end to "forum threads to nowhere" by making sure people find the best answers possible. 

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -27,6 +27,8 @@ In addition to the core content on this site, we maintain a library of quality e
 ### Development and Workflow
 [link-library settings="1" categorylistoverride="13"]  
 
+Have something to add to this page? [File an issue on GitHub](https://github.com/pantheon-systems/wordpress-at-scale/issues/new?labels=resource) and we can consider adding it to the library.
+
 <!---
 Do not edit below this line. Automatically pulls in resources.
 -->


### PR DESCRIPTION
Created a GitHub style contributions guideline doc, and made the web page more website-centric (with a link to the technical guidelines, of course)
